### PR TITLE
Dev linux test

### DIFF
--- a/io_csv.go
+++ b/io_csv.go
@@ -214,7 +214,7 @@ func (w *CsvWriter) Write() DataFrame {
 	}
 
 	if w.path != "" {
-		file, err := os.OpenFile(w.path, os.O_CREATE, 0666)
+		file, err := os.OpenFile(w.path, os.O_CREATE|os.O_WRONLY, 0666)
 		if err != nil {
 			return BaseDataFrame{err: err, ctx: w.dataframe.GetContext()}
 		}

--- a/io_csv_test.go
+++ b/io_csv_test.go
@@ -414,3 +414,26 @@ func Benchmark_FromCsv_500000Rows(b *testing.B) {
 		b.Error("Expected Int64, got", df.Types()[8].ToString())
 	}
 }
+
+func Test_IOCsv_ValidWrite(t *testing.T) {
+	df := NewBaseDataFrame(ctx).
+		AddSeriesFromFloat64s("a", []float64{1, 2, 3}, nil, false).
+		AddSeriesFromStrings("b", []string{"a", "b", "c"}, nil, false).
+		ToXlsx().
+		SetPath("test.csv").
+		Write()
+
+	if df.IsErrored() {
+		t.Errorf(df.GetError().Error())
+	}
+
+	_, err := os.Stat("test.csv")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	err = os.Remove("test.csv")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+}

--- a/io_html.go
+++ b/io_html.go
@@ -68,7 +68,7 @@ func (w *HtmlWriter) Write() DataFrame {
 	}
 
 	if w.path != "" {
-		file, err := os.OpenFile(w.path, os.O_CREATE, 0666)
+		file, err := os.OpenFile(w.path, os.O_CREATE|os.O_WRONLY, 0644)
 		if err != nil {
 			return BaseDataFrame{err: err, ctx: w.dataframe.GetContext()}
 		}

--- a/io_html_test.go
+++ b/io_html_test.go
@@ -1,0 +1,30 @@
+package gandalff
+
+import (
+	"os"
+
+	"testing"
+)
+
+func Test_IOHtml_ValidWrite(t *testing.T) {
+	df := NewBaseDataFrame(ctx).
+		AddSeriesFromFloat64s("a", []float64{1, 2, 3}, nil, false).
+		AddSeriesFromStrings("b", []string{"a", "b", "c"}, nil, false).
+		ToXlsx().
+		SetPath("test.html").
+		Write()
+
+	if df.IsErrored() {
+		t.Errorf(df.GetError().Error())
+	}
+
+	_, err := os.Stat("test.html")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	err = os.Remove("test.html")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+}

--- a/io_json.go
+++ b/io_json.go
@@ -229,7 +229,7 @@ func (w *JsonWriter) Write() DataFrame {
 	}
 
 	if w.path != "" {
-		file, err := os.OpenFile(w.path, os.O_CREATE, 0666)
+		file, err := os.OpenFile(w.path, os.O_CREATE|os.O_WRONLY, 0666)
 		if err != nil {
 			return BaseDataFrame{err: err, ctx: w.dataframe.GetContext()}
 		}

--- a/io_json_test.go
+++ b/io_json_test.go
@@ -1,0 +1,30 @@
+package gandalff
+
+import (
+	"os"
+
+	"testing"
+)
+
+func Test_IOJson_ValidWrite(t *testing.T) {
+	df := NewBaseDataFrame(ctx).
+		AddSeriesFromFloat64s("a", []float64{1, 2, 3}, nil, false).
+		AddSeriesFromStrings("b", []string{"a", "b", "c"}, nil, false).
+		ToXlsx().
+		SetPath("test.json").
+		Write()
+
+	if df.IsErrored() {
+		t.Errorf(df.GetError().Error())
+	}
+
+	_, err := os.Stat("test.json")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	err = os.Remove("test.json")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+}

--- a/io_markdown.go
+++ b/io_markdown.go
@@ -69,7 +69,7 @@ func (w *MarkDownWriter) Write() DataFrame {
 	}
 
 	if w.path != "" {
-		file, err := os.OpenFile(w.path, os.O_CREATE, 0666)
+		file, err := os.OpenFile(w.path, os.O_CREATE|os.O_WRONLY, 0666)
 		if err != nil {
 			return BaseDataFrame{err: err, ctx: w.dataframe.GetContext()}
 		}

--- a/io_markdown_test.go
+++ b/io_markdown_test.go
@@ -1,0 +1,30 @@
+package gandalff
+
+import (
+	"os"
+
+	"testing"
+)
+
+func Test_IOMd_ValidWrite(t *testing.T) {
+	df := NewBaseDataFrame(ctx).
+		AddSeriesFromFloat64s("a", []float64{1, 2, 3}, nil, false).
+		AddSeriesFromStrings("b", []string{"a", "b", "c"}, nil, false).
+		ToXlsx().
+		SetPath("test.md").
+		Write()
+
+	if df.IsErrored() {
+		t.Errorf(df.GetError().Error())
+	}
+
+	_, err := os.Stat("test.md")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	err = os.Remove("test.md")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+}

--- a/io_xlsx.go
+++ b/io_xlsx.go
@@ -205,7 +205,7 @@ func (w *XlsxWriter) Write() DataFrame {
 	}
 
 	if w.path != "" {
-		file, err := os.OpenFile(w.path, os.O_CREATE, 0666)
+		file, err := os.OpenFile(w.path, os.O_CREATE|os.O_WRONLY, 0644)
 		if err != nil {
 			return BaseDataFrame{err: err, ctx: w.dataframe.GetContext()}
 		}

--- a/io_xlsx.go
+++ b/io_xlsx.go
@@ -205,7 +205,8 @@ func (w *XlsxWriter) Write() DataFrame {
 	}
 
 	if w.path != "" {
-		file, err := os.OpenFile(w.path, os.O_CREATE|os.O_WRONLY, 0644)
+		// make sure os.O_WRONLY arg is supplies so that file is not opened in read-only mode
+		file, err := os.OpenFile(w.path, os.O_CREATE|os.O_WRONLY, 0666)
 		if err != nil {
 			return BaseDataFrame{err: err, ctx: w.dataframe.GetContext()}
 		}

--- a/io_xlsx_test.go
+++ b/io_xlsx_test.go
@@ -1,0 +1,30 @@
+package gandalff
+
+import (
+	"os"
+
+	"testing"
+)
+
+func Test_IOXlsx_ValidWrite(t *testing.T) {
+	df := NewBaseDataFrame(ctx).
+		AddSeriesFromFloat64s("a", []float64{1, 2, 3}, nil, false).
+		AddSeriesFromStrings("b", []string{"a", "b", "c"}, nil, false).
+		ToXlsx().
+		SetPath("test.xlsx").
+		Write()
+
+	if df.IsErrored() {
+		t.Errorf(df.GetError().Error())
+	}
+
+	_, err := os.Stat("test.xlsx")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	err = os.Remove("test.xlsx")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+}

--- a/io_xpt.go
+++ b/io_xpt.go
@@ -165,7 +165,7 @@ func (w *XptWriter) Write() DataFrame {
 	}
 
 	if w.path != "" {
-		file, err := os.OpenFile(w.path, os.O_CREATE|os.O_WRONLY, 0644)
+		file, err := os.OpenFile(w.path, os.O_CREATE|os.O_WRONLY, 0666)
 		if err != nil {
 			return BaseDataFrame{err: err, ctx: w.dataframe.GetContext()}
 		}

--- a/io_xpt.go
+++ b/io_xpt.go
@@ -165,7 +165,7 @@ func (w *XptWriter) Write() DataFrame {
 	}
 
 	if w.path != "" {
-		file, err := os.OpenFile(w.path, os.O_CREATE, 0666)
+		file, err := os.OpenFile(w.path, os.O_CREATE|os.O_WRONLY, 0644)
 		if err != nil {
 			return BaseDataFrame{err: err, ctx: w.dataframe.GetContext()}
 		}

--- a/io_xpt_test.go
+++ b/io_xpt_test.go
@@ -2,7 +2,10 @@ package gandalff
 
 import (
 	"encoding/binary"
+	"os"
+
 	"math"
+
 	"testing"
 )
 
@@ -194,6 +197,25 @@ func Test_IOXpt_VeryVerySmallMagnitudeFloats(t *testing.T) {
 	}
 }
 
-// func Test_IOXpt_Genericv56(t *testing.T) {
-// 	ReadXPTv56("Z:\\Intertek\\2794 2 outcomes at 2 measures and 2-1distance\\Analysis\\Results + Reports\\XPT_data\\sp.xpt")
-// }
+func Test_IOXpt_ValidWrite(t *testing.T) {
+	df := NewBaseDataFrame(ctx).
+		AddSeriesFromFloat64s("a", []float64{1, 2, 3}, nil, false).
+		AddSeriesFromStrings("b", []string{"a", "b", "c"}, nil, false).
+		ToXpt().
+		SetPath("test.xpt").
+		Write()
+
+	if df.IsErrored() {
+		t.Errorf(df.GetError().Error())
+	}
+
+	_, err := os.Stat("test.xpt")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	err = os.Remove("test.xpt")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+}


### PR DESCRIPTION
Branch focused on fixing 'bad descriptor' errors produced by io writers. A test for each io writer was also added 

For context, the bad descriptor error occurs due to a discrepancy between Windows and Linux. On Windows you do not need to explicitly add a write flag but on Linux the write flag is needed to define the access mode, O_WRONLY (write-only) as follows:

`file, err := os.OpenFile(w.path, os.O_CREATE|os.O_WRONLY, 0666)`

 Otherwise, you get the read-only file descriptor by default. 